### PR TITLE
Fix: Robust Auth State Management and Offline Support (#53, #51)

### DIFF
--- a/src/core/services/firebase.ts
+++ b/src/core/services/firebase.ts
@@ -1,6 +1,11 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import {
+    getFirestore,
+    initializeFirestore,
+    persistentLocalCache,
+    persistentMultipleTabManager
+} from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
@@ -15,7 +20,14 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
-const db = getFirestore(app);
+
+// Initialize Firestore with persistence on the client
+const db = typeof window !== "undefined"
+    ? initializeFirestore(app, {
+        localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() })
+    })
+    : getFirestore(app);
+
 const storage = getStorage(app);
 
 export { app, auth, db, storage };

--- a/src/features/auth/hooks/use-auth.test.ts
+++ b/src/features/auth/hooks/use-auth.test.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../services/auth-service';
 
 vi.mock('../services/auth-service', () => ({
     AuthService: {
-        onAuthStateChanged: vi.fn(),
+        onAuthStateChanged: vi.fn(() => () => { }),
         getUserProfile: vi.fn(),
         mapFirebaseUserToUser: vi.fn(),
     },
@@ -14,6 +14,11 @@ vi.mock('../services/auth-service', () => ({
 describe('useAuth', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // Assuming we can access the hook's result to call reset, 
+        // but better to mock or call the store directly if possible.
+        // However, useAuth returns the store functions.
+        const { result } = renderHook(() => useAuth());
+        result.current.reset();
     });
 
     it('should initialize with loading state', async () => {
@@ -30,7 +35,15 @@ describe('useAuth', () => {
 
     it('should update state when user is authenticated', async () => {
         const mockFirebaseUser = { uid: '123', email: 'test@test.com' };
-        const mockProfile = { uid: '123', email: 'test@test.com', displayName: 'Test User' };
+        const mockProfile: any = {
+            uid: '123',
+            email: 'test@test.com',
+            displayName: 'Test User',
+            photoURL: null,
+            bio: '',
+            createdAt: new Date() as any,
+            updatedAt: new Date() as any,
+        };
 
         vi.mocked(AuthService.onAuthStateChanged).mockImplementation((cb: any) => {
             cb(mockFirebaseUser);


### PR DESCRIPTION
This PR provides the final fix for auth-related stability issues:
1. **Infinite Loop**: Refactored \useAuth\ to use a singleton store-based initialization, preventing multiple subscriptions and re-render loops.
2. **Offline Error**: Enabled Firestore persistence in \irebase.ts\ to handle network fluctuations and 'client offline' errors.
3. **Internal Logic**: Expose stable state selectors and added a \eset\ mechanism for clean testing.
Verified with unit tests (\use-auth.test.ts\) and successful \
ext build\.