### PR TITLE
fix: resolve Firebase addDoc error with undefined location

### DIFF
--- a/src/app/posts/create/env-lock/page.tsx
+++ b/src/app/posts/create/env-lock/page.tsx
@@ -22,7 +22,7 @@ export default function EnvLockPage() {
           lightDirection: profile.lightDirection,
           experienceLevel: profile.experienceLevel,
           userId: profile.userId,
-          location: profile.location
+          location: profile.location || null
         } as any
       });
     }

--- a/src/core/services/firebase.ts
+++ b/src/core/services/firebase.ts
@@ -22,7 +22,9 @@ const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const auth = getAuth(app);
 
 // Initialize Firestore
-const db = getFirestore(app);
+const db = initializeFirestore(app, {
+    ignoreUndefinedProperties: true,
+});
 
 const storage = getStorage(app);
 


### PR DESCRIPTION
## Description
This PR fixes a bug where posts could not be created if the user profile had an undefined location field.

## Changes
- Enabled ignoreUndefinedProperties in Firestore initialization.
- Added a fallback to 
ull for the location field in the post creation wizard.

Closes #105